### PR TITLE
Changed "Install conky" to "Install conky-all"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For older versions, check the available [releases](../../releases).
 
 ####Installation:
 
-* Install **conky**, **curl** and **jq**.
+* Install **conky-all**, **curl** and **jq**.
 
 * Make sure you have the **Droid Sans** font installed.
 


### PR DESCRIPTION
In all normal package managers like apt or yum `conky` just has the `conky-std` package as a dependency, but harmattan needs `conky-all`.
